### PR TITLE
Connect already closed error.

### DIFF
--- a/driver/driver.go
+++ b/driver/driver.go
@@ -10,7 +10,7 @@ import (
 
 var (
 	ErrLocked                  = fmt.Errorf("can't acquire lock")
-	ErrConnectionAlreadyClosed = fmt.Errorf("connection already closed")
+	ErrFailedToSendCloseNotify = fmt.Errorf("failed to send closeNotify alert, please see https://github.com/jackc/pgx/issues/984 for more details")
 )
 
 // Driver is the interface type that needs to implemented by all drivers.

--- a/driver/driver.go
+++ b/driver/driver.go
@@ -9,7 +9,8 @@ import (
 )
 
 var (
-	ErrLocked = fmt.Errorf("can't acquire lock")
+	ErrLocked                  = fmt.Errorf("can't acquire lock")
+	ErrConnectionAlreadyClosed = fmt.Errorf("connection already closed")
 )
 
 // Driver is the interface type that needs to implemented by all drivers.

--- a/driver/generic/generic.go
+++ b/driver/generic/generic.go
@@ -120,9 +120,9 @@ func (driver *Driver) ensureConnectionNotClosed() error {
 	return nil
 }
 
-func (driver *Driver) Close() error {
-	if err := driver.db.Close(); err != nil {
-		return err
+func (p *Driver) Close() error {
+	if err := p.db.Close(); err != nil {
+		return driver.WrapErrFailedToSendCloseNotify(err)
 	}
 	return nil
 }

--- a/driver/postgres/postgres.go
+++ b/driver/postgres/postgres.go
@@ -11,7 +11,6 @@ import (
 	"github.com/jfrog/go-dbmigrate/driver"
 	"github.com/jfrog/go-dbmigrate/file"
 	"github.com/jfrog/go-dbmigrate/migrate/direction"
-	"strings"
 )
 
 type Driver struct {
@@ -62,13 +61,7 @@ func (driver *Driver) ensureConnectionNotClosed() error {
 
 func (p *Driver) Close() error {
 	if err := p.db.Close(); err != nil {
-		//https://github.com/jackc/pgx/issues/984
-		//In Azure Pgx is throwing an error while the close is called on a connection.
-		//The code below will wrap a custom error type, which will allow the consumer to ignore it.
-		if strings.Contains(err.Error(), "failed to send closeNotify alert (but connection was closed anyway): write tcp") {
-			return fmt.Errorf(err.Error()+": %w", driver.ErrConnectionAlreadyClosed)
-		}
-		return err
+		return driver.WrapErrFailedToSendCloseNotify(err)
 	}
 	return nil
 }

--- a/driver/util.go
+++ b/driver/util.go
@@ -17,3 +17,13 @@ func GenerateAdvisoryLockId(databaseName string, additionalNames ...string) (str
 	sum = sum * uint32(advisoryLockIDSalt)
 	return fmt.Sprint(sum), nil
 }
+
+func WrapErrFailedToSendCloseNotify(err error) error {
+	//https://github.com/jackc/pgx/issues/984
+	//In Azure Pgx is throwing an error while the close is called on a connection.
+	//The code below will wrap a custom error type, which will allow the consumer to ignore it.
+	if strings.Contains(err.Error(), "failed to send closeNotify alert (but connection was closed anyway)") {
+		return fmt.Errorf(err.Error()+": %w", ErrFailedToSendCloseNotify)
+	}
+	return err
+}


### PR DESCRIPTION
In Azure, the pgx library throws an error while trying to close the connection. We are wrapping the error here with a custom message which allows the client to ignore if they want to.